### PR TITLE
Fix compilation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
     let months_model = months;
     let years_model = years;
 
-    ui.set_days(ModelRc::new(days_model.clone()));
+    ui.set_days(ModelRc::from(days_model.clone()));
     ui.set_months(months_model);
     ui.set_years(years_model);
     let _appwin_weak = ui.as_weak();


### PR DESCRIPTION
As part of the QA for Slint, we're compiling some github repo that uses slint to see if they still compile with the newer version.
In this case this is just a change that was made in the version 0.2

Note: another way to fix that would be to not put the model in a Rc